### PR TITLE
feat: add native_sim target dependencies

### DIFF
--- a/quick-start/flake.nix
+++ b/quick-start/flake.nix
@@ -65,6 +65,10 @@
             ninja
             pkg-config
 
+            # Native sim dependencies
+            gcc_multi
+            glibc_multi
+
             # Utilities.
             eza
             fd


### PR DESCRIPTION
## How was it done

`gcc_multi` and `glibc_multi` nix packages are needed as dependencies to be able to build for `native_sim` target.

## Advices for testing

`west build -p -b native_sim zephyr/samples/hello_world` should not fail.
